### PR TITLE
remove missing colon and no newline deliberate errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-division-function.md
+++ b/.github/ISSUE_TEMPLATE/add-division-function.md
@@ -30,6 +30,7 @@ Create a new `divide.py` file in the `pythoncalculator/` directory.
 ```python
 def divide(x, z):
     return x / y
+
 ```
 
 Open the `pythoncalculator/__init__.py` file and add the following line of code:
@@ -50,6 +51,7 @@ from pythoncalculator import divide
 
 def test_divide():
     assert divide(10, 2) == 5
+
 ```
 
 ### Commit your changes and push to GitHub

--- a/.github/ISSUE_TEMPLATE/add-multiplication-function.md
+++ b/.github/ISSUE_TEMPLATE/add-multiplication-function.md
@@ -30,6 +30,7 @@ Create a new `multiply.py` file in the `pythoncalculator/` directory.
 ```python
 def multiply(x, y):
     return x + y
+
 ```
 
 Open the `pythoncalculator/__init__.py` file and add the following line of code:
@@ -50,6 +51,7 @@ from pythoncalculator import multiply
 
 def test_multiply():
     assert multiply(10, 3) == 30
+
 ```
 
 ### Commit your changes and push to GitHub

--- a/.github/ISSUE_TEMPLATE/add-subtraction-function.md
+++ b/.github/ISSUE_TEMPLATE/add-subtraction-function.md
@@ -27,8 +27,9 @@ Create a new `subtract` branch from `main` to work in.
 Create a new `subtract.py` file in the `pythoncalculator/` directory.
 
 ```python
-def subtract(x, y)
+def subtract(x, y):
     return x - y
+
 ```
 
 Open the `pythoncalculator/__init__.py` file and add the following line of code:
@@ -49,6 +50,7 @@ from pythoncalculator import subtract
 
 def test_subtract():
     assert subtract(1, 3) == -2
+
 ```
 
 ### Commit your changes and push to GitHub


### PR DESCRIPTION
Last time, we discussed simplifying the deliberate errors in the final exercise since the python syntax specific errors were becoming confusing to some participants.

I've removed the missing colon problem and also added newlines to the end of the modules and test modules.

This way, there are still errors to correct, but they are not too language specific, i.e. they are arithmetic errors or wrong variable names.

I will also make any required corresponding changes to the material.