### PR TITLE
Update version of Python used for this exercise

### DIFF
--- a/.github/workflows/test-python-package.yaml
+++ b/.github/workflows/test-python-package.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Make sure you have [conda](https://conda.io/projects/conda/en/latest/user-guide/
 ### Create conda environment
 
 ```
-conda create --name python-calculator python=3.8
+conda create --name python-calculator python=3.14
 ```
 
 ### Activate conda environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-attrs==21.2.0
-certifi==2020.12.5
-iniconfig==1.1.1
-packaging==20.9
-pluggy==0.13.1
-py==1.10.0
-pyparsing==2.4.7
-pytest==6.2.4
+attrs==25.4.0
+certifi==2025.10.5
+iniconfig==2.3.0
+packaging==25.0
+pluggy==1.6.0
+py==1.11.0
+pyparsing==3.2.5
+pytest==8.4.2
 toml==0.10.2


### PR DESCRIPTION
fixes #10 

Updates the version of python for this repo:
- The README now refers to the most recently released version `3.14`
- The workflow now tests against `3.14`, `3.13` and `3.12`

Also updates the dependencies in `requirements.txt` to their most recent versions